### PR TITLE
Add Subtitute User activity id to Authentication Class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ Thankyou! -->
   1. Added `raw_data_hash` as an attribute to `base_event`. [#1420](https://github.com/ocsf/ocsf-schema/pull/1420)
   1. Added `Add Subgroup`, and `Remove Subgroup` activities in the `Group Management` class. [#1447](https://github.com/ocsf/ocsf-schema/pull/1447)
   1. Added `MTA Relay` activity and `to`/`from` attributes to the `Email Activity` class. [#1454](https://github.com/ocsf/ocsf-schema/pull/1454)
-  1. Added `Substitute User` activity_id to the `Authentication` class.
+  1. Added `Account Switch` activity_id to the `Authentication` class. Added `account_switch_type` and `account_switch_type_id` attributes to the `Authentication` class.
 
 * #### Objects
   1. Added more `algorithm_id` values and references to the `fingerprint` object. [#1412](https://github.com/ocsf/ocsf-schema/pull/1412)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ Thankyou! -->
   1. Added `raw_data_hash` as an attribute to `base_event`. [#1420](https://github.com/ocsf/ocsf-schema/pull/1420)
   1. Added `Add Subgroup`, and `Remove Subgroup` activities in the `Group Management` class. [#1447](https://github.com/ocsf/ocsf-schema/pull/1447)
   1. Added `MTA Relay` activity and `to`/`from` attributes to the `Email Activity` class. [#1454](https://github.com/ocsf/ocsf-schema/pull/1454)
-  1. Added `Substitute User` activity_id to the `Authentication` class. [#1456](https://github.com/ocsf/ocsf-schema/pull/1456)
+  1. Added `Substitute User` activity_id to the `Authentication` class.
 
 * #### Objects
   1. Added more `algorithm_id` values and references to the `fingerprint` object. [#1412](https://github.com/ocsf/ocsf-schema/pull/1412)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Thankyou! -->
   1. Added `raw_data_hash` as an attribute to `base_event`. [#1420](https://github.com/ocsf/ocsf-schema/pull/1420)
   1. Added `Add Subgroup`, and `Remove Subgroup` activities in the `Group Management` class. [#1447](https://github.com/ocsf/ocsf-schema/pull/1447)
   1. Added `MTA Relay` activity and `to`/`from` attributes to the `Email Activity` class. [#1454](https://github.com/ocsf/ocsf-schema/pull/1454)
+  1. Added `Substitute User` activity_id to the `Authentication` class. [#1456](https://github.com/ocsf/ocsf-schema/pull/1456)
 
 * #### Objects
   1. Added more `algorithm_id` values and references to the `fingerprint` object. [#1412](https://github.com/ocsf/ocsf-schema/pull/1412)

--- a/dictionary.json
+++ b/dictionary.json
@@ -99,6 +99,35 @@
       "description": "The account object describes details about the account that was the source or target of the activity.",
       "type": "account"
     },
+    "account_switch_type": {
+      "caption": "Account Switch Type",
+      "description": "The account switch method, normalized to the caption of the account_switch_type_id value. In the case of 'Other', it is defined by the event source.",
+      "type": "string_t"
+    },
+    "account_switch_type_id": {
+      "caption": "Account Switch Type ID",
+      "description": "The normalized identifier of the account switch method.",
+      "sibling": "account_switch_type",
+      "type": "integer_t",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The account switch type is unknown."
+        },
+        "1": {
+          "caption": "Substitute User",
+          "description": "A utility like <code>sudo</code>, <code>su</code>, or equivalent was used to perform actions in the context of another user."
+        },
+        "2": {
+          "caption": "Impersonate",
+          "description": "A Kerberos service is acting with the permissions of another user."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The account switch type is not mapped. See the <code>account_switch_type</code> attribute, which contains a data source specific value."
+        }
+      }
+    },
     "ack_reason": {
       "caption": "Acknowledgement Reason",
       "description": "An integer that provides a reason code or additional information about the acknowledgment result.",
@@ -5778,35 +5807,6 @@
       "caption": "Service Name",
       "description": "The service name in service-to-service connections. For example, AWS VPC logs the pkt-src-aws-service and pkt-dst-aws-service fields identify the connection is coming from or going to an AWS service.",
       "type": "string_t"
-    },
-    "account_switch_type": {
-      "caption": "Account Switch Type",
-      "description": "The account switch method, normalized to the caption of the account_switch_type_id value. In the case of 'Other', it is defined by the event source.",
-      "type": "string_t"
-    },
-    "account_switch_type_id": {
-      "caption": "Account Switch Type ID",
-      "description": "The normalized identifier of the account switch method.",
-      "sibling": "account_switch_type",
-      "type": "integer_t",
-      "enum": {
-        "0": {
-          "caption": "Unknown",
-          "description": "The account switch type is unknown."
-        },
-        "1": {
-          "caption": "Substitute User",
-          "description": "A utility like <code>sudo</code>, <code>su</code>, or equivalent was used to perform actions in the context of another user."
-        },
-        "2": {
-          "caption": "Impersonate",
-          "description": "A Kerberos service is acting with the permissions of another user."
-        },
-        "99": {
-          "caption": "Other",
-          "description": "The account switch type is not mapped. See the <code>account_switch_type</code> attribute, which contains a data source specific value."
-        }
-      }
     },
     "system_call": {
       "caption": "System Call",

--- a/dictionary.json
+++ b/dictionary.json
@@ -5779,6 +5779,35 @@
       "description": "The service name in service-to-service connections. For example, AWS VPC logs the pkt-src-aws-service and pkt-dst-aws-service fields identify the connection is coming from or going to an AWS service.",
       "type": "string_t"
     },
+    "account_switch_type": {
+      "caption": "Account Switch Type",
+      "description": "The account switch method, normalized to the caption of the account_switch_type_id value. In the case of 'Other', it is defined by the event source.",
+      "type": "string_t"
+    },
+    "account_switch_type_id": {
+      "caption": "Account Switch Type ID",
+      "description": "The normalized identifier of the account switch method.",
+      "sibling": "account_switch_type",
+      "type": "integer_t",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The account switch type is unknown."
+        },
+        "1": {
+          "caption": "Substitute User",
+          "description": "A utility like <code>sudo</code>, <code>su</code>, or equivalent was used to perform actions in the context of another user."
+        },
+        "2": {
+          "caption": "Impersonate",
+          "description": "A Kerberos service is acting with the permissions of another user."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The account switch type is not mapped. See the <code>account_switch_type</code> attribute, which contains a data source specific value."
+        }
+      }
+    },
     "system_call": {
       "caption": "System Call",
       "description": "The system call that was invoked.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -120,7 +120,7 @@
         },
         "2": {
           "caption": "Impersonate",
-          "description": "A Kerberos service is acting with the permissions of another user."
+          "description": "An API like <code>ImpersonateLoggedOnUser()</code> or equivalent was used to perform actions in the context of another user."
         },
         "99": {
           "caption": "Other",

--- a/events/iam/authentication.json
+++ b/events/iam/authentication.json
@@ -47,7 +47,7 @@
         },
         "7": {
           "caption": "Substitute User",
-          "description": "A user attempted to authenticate as another user"
+          "description": "A utility like <code>sudo</code>, <code>su</code>, or equivalent was used to perform actions in the context of another user."
         }
       }
     },

--- a/events/iam/authentication.json
+++ b/events/iam/authentication.json
@@ -19,6 +19,14 @@
     ]
   },
   "attributes": {
+    "account_switch_type": {
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "account_switch_type_id": {
+      "group": "primary",
+      "requirement": "recommended"
+    },
     "activity_id": {
       "enum": {
         "1": {
@@ -46,8 +54,8 @@
           "description": "A preauthentication stage was engaged."
         },
         "7": {
-          "caption": "Substitute User",
-          "description": "A utility like <code>sudo</code>, <code>su</code>, or equivalent was used to perform actions in the context of another user."
+          "caption": "Account Switch",
+          "description": "A utility or service switched the user account. See the <code>account_switch_type_id</code> attribute for more details."
         }
       }
     },

--- a/events/iam/authentication.json
+++ b/events/iam/authentication.json
@@ -44,6 +44,10 @@
         "6": {
           "caption": "Preauth",
           "description": "A preauthentication stage was engaged."
+        },
+        "7": {
+          "caption": "Substitute User",
+          "description": "A user attempted to authenticate as another user"
         }
       }
     },


### PR DESCRIPTION
#### Related Issue: n/a

#### Description of changes:

Added a new `Account Switch` activity_id to the `Authentication` class to handle the events that switch the user account. 
Added account_switch_type and account_switch_type_id to the `Authentication` class with the following types:
- Substitute User: caused by `sudo` and `su` commands on Unix systems. `sudo` and `su` both use authentication to allow the user to effectively act as another user either in a single command or in a specific session.
- Impersonate: caused by the `ImpersonateLoggedOnUser()` command on Windows systems, or similar. 

<img width="1572" height="835" alt="image" src="https://github.com/user-attachments/assets/83a8af8e-c07e-4375-afb1-b134485aee6e" />